### PR TITLE
Add default case to `setConstants()`

### DIFF
--- a/commonjs/lib/constants.js
+++ b/commonjs/lib/constants.js
@@ -31,6 +31,7 @@ function setConstants() { //set these automatically based on the browser url
     switch (local.baseurl) {
     case 'ropewiki.com': //prod
     case 'www.ropewiki.com': //prod
+    default:
         SITE_HOSTNAME = local.baseurl;
         LUCA_HOSTNAME = "ropewiki.com/luca";
         //GOOGLE_MAPS_APIKEY = "AIzaSyDdkcexZV-p5Nj8RwgLYTcegm5jorJpbyw"; //ben's


### PR DESCRIPTION
Adding a default means new dev copies of the site will default to behaving like production. New values can then be added for a specific dev site later if they need to point elsewhere.

This fixes dev-site problem of tables missing underneath maps & images missing in tables.

**Test process:** 
Edited local js directly via `http://ropewiki.ak/MediaWiki:Common.js`.


**Before** (map & table broken)

![Screenshot from 2023-06-03 21-43-03](https://github.com/RopeWiki/commonjs/assets/131580/e30770b8-3a4e-4c9c-8d79-be146b72bc6f)

**After** (map still broken due to invalid API key - but table is working)

![Screenshot from 2023-06-03 21-42-32](https://github.com/RopeWiki/commonjs/assets/131580/3bfdf939-bbf5-4a05-91ac-7fa8d8d8a70b)

Also confirmed that on other pages where tables did load before, that images are no longer broken too.

