### PR TITLE
Fix slideshow controls alignment

### DIFF
--- a/commonjs/lib/ui/ui.js
+++ b/commonjs/lib/ui/ui.js
@@ -506,6 +506,14 @@ function loadUserInterface(document) {
                 });
         }
 
+    // fix SRF slideshow: center page number, align slider, and fix button shape
+    var slideshowStyle = document.createElement('style');
+    slideshowStyle.innerHTML =
+        '.srf-slideshow .slideshow-nav-readout { left: 0; }' +
+        '.srf-slideshow .slideshow-nav.ui-slider { margin-top: 0; margin-bottom: 0; }' +
+        '.srf-slideshow .slideshow-nav-wrapper .ui-button-icon-only { border-radius: 4px; }';
+    document.body.appendChild(slideshowStyle);
+
     //gallerybox
     var tt, it, isrc = null, ttmove = 0, ttshow = 0;
     var boxes = document.getElementsByClassName('galleryboxview');


### PR DESCRIPTION
## Summary

Small PR to fix the slider alignment

- Centers the page number readout by removing the default `left: -0.3em` offset on `.slideshow-nav-readout`
- Aligns the slider with the pause button by zeroing the asymmetric vertical margins (`-11px` top, `7px` bottom) on the jQuery UI slider
- Rounds all corners of the pause button evenly instead of only the right side (`ui-corner-right`)

Before
<img width="633" height="819" alt="image" src="https://github.com/user-attachments/assets/e12eefdc-b008-418a-b8ca-8023456c0a85" />

After
<img width="619" height="813" alt="image" src="https://github.com/user-attachments/assets/982282dc-4273-434a-a4c5-dc2b4e4c5dab" />


Console commands to test before merging:
```js
var s = document.createElement('style');
s.innerHTML = '.srf-slideshow .slideshow-nav-readout { left: 0; } .srf-slideshow .slideshow-nav.ui-slider { margin-top: 0; margin-bottom: 0; } .srf-slideshow .slideshow-nav-wrapper .ui-button-icon-only { border-radius: 4px; }';
document.body.appendChild(s);
```